### PR TITLE
feat(garden): changing garden note to description

### DIFF
--- a/app/components/gardens/GardenForm.tsx
+++ b/app/components/gardens/GardenForm.tsx
@@ -67,7 +67,7 @@ export function GardenForm({
       </div>
       <div className="flex flex-col gap-1">
         <label htmlFor="notes" className="text-sm font-medium text-gray-700">
-          Notes
+          Description
         </label>
         <textarea
           id="notes"

--- a/app/routes/_app.gardens.$gardenSlug._index.tsx
+++ b/app/routes/_app.gardens.$gardenSlug._index.tsx
@@ -536,6 +536,17 @@ function GardenDashboardView({
 
   return (
     <>
+      {garden.notes && (
+        <section className="mb-6">
+          <article className="rounded-3xl border border-black/10 bg-surface p-5 shadow-soft sm:p-6">
+            <div className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">
+              Description
+            </div>
+            <p className="text-sm leading-7 text-text-main">{garden.notes}</p>
+          </article>
+        </section>
+      )}
+
       <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
         <PlantKPICard
           label="Garden Age"


### PR DESCRIPTION
Changing Garden note to Description and showing it on the garden dashboard

fixes #64
